### PR TITLE
setting yatspec output folder to target/yatspec

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,17 @@
                     <target>${java.version}</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <!--location of the yatspec a/t output-->
+                        <yatspec.output.dir>${project.build.directory}/yatspec</yatspec.output.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Hi tad,
Very grateful to you for doing this, I've been trying to remember how to render sequence diagrams in an A/T for ages.
Noticed the reports are being written to default location (java.io.tmpdir), this commit changes it to target/yatspec.
What I'm hoping todo is get the reports hosted on travis, so we can show them to people, without needing to run the build.
Incase travis doesn't do this for free, please consider using circle.ci it keeps the artifacts from the build. i.e.
https://79-28635373-gh.circle-artifacts.com/0/home/ubuntu/embers/embers-acceptance-tests/build/reports/acceptance/adf/embers/e2e/PuttingItAllTogetherTest.html

Regards
Alfanse